### PR TITLE
feat: add /ed reload and auto-populate new enchants; harden null-safety

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -9,8 +9,5 @@
         <module name="EnchantmentDisabler" />
       </profile>
     </annotationProcessing>
-    <bytecodeTargetLevel>
-      <module name="EnchantmentDisabler" target="1.8" />
-    </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,6 +5,7 @@
       <item index="0" class="java.lang.String" itemvalue="org.bukkit.event.EventHandler" />
     </list>
   </component>
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="MavenProjectsManager">
     <option name="originalFiles">
       <list>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/EnchantmentDisabler.iml
+++ b/EnchantmentDisabler.iml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+<module version="4">
   <component name="FacetManager">
     <facet type="minecraft" name="Minecraft">
       <configuration>
@@ -10,63 +10,5 @@
         <projectReimportVersion>1</projectReimportVersion>
       </configuration>
     </facet>
-  </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
-    <output url="file://$MODULE_DIR$/target/classes" />
-    <output-test url="file://$MODULE_DIR$/target/test-classes" />
-    <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
-      <excludeFolder url="file://$MODULE_DIR$/target" />
-    </content>
-    <orderEntry type="inheritedJdk" />
-    <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:guava:32.1.2-jre" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:failureaccess:1.0.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.findbugs:jsr305:3.0.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.errorprone:error_prone_annotations:2.18.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.j2objc:j2objc-annotations:2.8" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.google.code.gson:gson:2.10.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.md-5:bungeecord-chat:1.20-R0.1-deprecated+build.14" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.yaml:snakeyaml:2.2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.joml:joml:1.10.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: com.googlecode.json-simple:json-simple:1.1.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: it.unimi.dsi:fastutil:8.5.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.logging.log4j:log4j-api:2.17.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:2.0.9" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven:maven-resolver-provider:3.9.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven:maven-model:3.9.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven:maven-model-builder:3.9.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.plexus:plexus-interpolation:1.26" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven:maven-artifact:3.9.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.commons:commons-lang3:3.12.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven:maven-builder-support:3.9.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.eclipse.sisu:org.eclipse.sisu.inject:0.9.0.M2" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven:maven-repository-metadata:3.9.6" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.resolver:maven-resolver-api:1.9.18" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.resolver:maven-resolver-spi:1.9.18" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.resolver:maven-resolver-util:1.9.18" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.resolver:maven-resolver-impl:1.9.18" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.maven.resolver:maven-resolver-named-locks:1.9.18" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.codehaus.plexus:plexus-utils:3.5.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.inject:javax.inject:1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-api:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-key:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:examination-api:1.3.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:examination-string:1.3.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.jetbrains:annotations:24.1.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-text-minimessage:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-text-serializer-gson:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-text-serializer-json:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:option:1.0.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-text-serializer-legacy:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-text-serializer-plain:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: net.kyori:adventure-text-logger-slf4j:4.15.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.checkerframework:checker-qual:3.33.0" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm:9.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-commons:9.5" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.ow2.asm:asm-tree:9.5" level="project" />
   </component>
 </module>

--- a/src/main/java/me/opd/enchantmentdisabler/EnchantmentDisablerPlugin.java
+++ b/src/main/java/me/opd/enchantmentdisabler/EnchantmentDisablerPlugin.java
@@ -41,17 +41,27 @@ public final class EnchantmentDisablerPlugin extends JavaPlugin {
 
         ConfigUtilsEN.loadHashMapFromConfig(this);
         //System.out.println(EnchantmentDisablerPlugin.blockedEnchants.toString());
-        allowedEnchant = new ArrayList<>();
-
-        for(Enchantment en : EnchantmentDisablerPlugin.blockedEnchants.keySet()){
-            if(!EnchantmentDisablerPlugin.blockedEnchants.get(en)){
-                EnchantmentDisablerPlugin.allowedEnchant.add(en);
-                //System.out.println("Enchant is allowed: " + en.toString());
-            }
-        }
+        rebuildAllowedEnchant();
     }
 
     public void onDisable(){
         ConfigUtilsEN.syncHashMapWithConfig(this);
+    }
+
+    public void reloadPluginConfigAndCaches(){
+        reloadConfig();
+        EnchantmentDisablerPlugin.blockedEnchants.clear();
+        EnchantmentDisablerPlugin.allowedEnchant.clear();
+        ConfigUtilsEN.loadHashMapFromConfig(this);
+        rebuildAllowedEnchant();
+    }
+
+    private void rebuildAllowedEnchant(){
+        allowedEnchant = new ArrayList<>();
+        for(Enchantment en : EnchantmentDisablerPlugin.blockedEnchants.keySet()){
+            if(Boolean.FALSE.equals(EnchantmentDisablerPlugin.blockedEnchants.get(en))){
+                EnchantmentDisablerPlugin.allowedEnchant.add(en);
+            }
+        }
     }
 }

--- a/src/main/java/me/opd/enchantmentdisabler/commands/MenuCommand.java
+++ b/src/main/java/me/opd/enchantmentdisabler/commands/MenuCommand.java
@@ -28,6 +28,16 @@ public class MenuCommand implements CommandExecutor {
     public boolean onCommand(CommandSender sender, Command cmd, String label, String args[]){
         //need 5 rows for inv
         if(cmd.getLabel().equalsIgnoreCase("ed")){
+            if(args != null && args.length > 0 && args[0].equalsIgnoreCase("reload")){
+                if(!sender.hasPermission("enchantmentdisabler.reload")){
+                    sender.sendMessage(ChatColor.RED + "You do not have permission to reload this plugin.");
+                    return true;
+                }
+                plugin.reloadPluginConfigAndCaches();
+                sender.sendMessage(ChatColor.GREEN + "EnchantmentDisabler config reloaded.");
+                return true;
+            }
+
             if(!(sender instanceof Player)){
                 sender.sendMessage(ChatColor.RED + "This command is for players only.");
                 return true;
@@ -52,13 +62,12 @@ public class MenuCommand implements CommandExecutor {
 
                 ArrayList<String> lore = new ArrayList<String>();
                 lore.add("");
-                //lore.add(ChatColor.GRAY + "" + en.getName());
-                if(EnchantmentDisablerPlugin.blockedEnchants.get(en) == true){
+                if(Boolean.TRUE.equals(EnchantmentDisablerPlugin.blockedEnchants.get(en))){
                     lore.add("§c§lDISABLED");
                 }else{
                     lore.add("§a§lENABLED");
                 }
-                String line = Boolean.valueOf(EnchantmentDisablerPlugin.blockedEnchants.get(en)) ? ChatColor.GRAY + "§7Click to §aEnable" : "§7Click to §cDisable";
+                String line = Boolean.TRUE.equals(EnchantmentDisablerPlugin.blockedEnchants.get(en)) ? ChatColor.GRAY + "§7Click to §aEnable" : "§7Click to §cDisable";
                 lore.add(line);
 
                 bookMeta.setLore(lore);

--- a/src/main/java/me/opd/enchantmentdisabler/listeners/EnchantItemListener.java
+++ b/src/main/java/me/opd/enchantmentdisabler/listeners/EnchantItemListener.java
@@ -43,7 +43,7 @@ public class EnchantItemListener implements Listener {
                 continue;
             }
 
-            if(!EnchantmentDisablerPlugin.blockedEnchants.get(entry.getKey())){
+            if(!Boolean.TRUE.equals(EnchantmentDisablerPlugin.blockedEnchants.get(entry.getKey()))){
                 continue;
             }
             toChange.add(entry.getKey());

--- a/src/main/java/me/opd/enchantmentdisabler/listeners/PrepareItemEnchantListener.java
+++ b/src/main/java/me/opd/enchantmentdisabler/listeners/PrepareItemEnchantListener.java
@@ -33,7 +33,7 @@ public class PrepareItemEnchantListener implements Listener {
 
             long altSeed = seed + eo.getCost();
 
-            if(EnchantmentDisablerPlugin.blockedEnchants.get(eo.getEnchantment())){
+            if(Boolean.TRUE.equals(EnchantmentDisablerPlugin.blockedEnchants.get(eo.getEnchantment()))){
                 Enchantment replacementEnchant = EnchantmentDisablerPlugin.enchantUtils.newChosenEnchantment(e.getItem(), altSeed);
 
                 int enchantLevel = ((eo.getCost() /30) * replacementEnchant.getMaxLevel());

--- a/src/main/java/me/opd/enchantmentdisabler/utils/ConfigUtilsEN.java
+++ b/src/main/java/me/opd/enchantmentdisabler/utils/ConfigUtilsEN.java
@@ -2,6 +2,7 @@ package me.opd.enchantmentdisabler.utils;
 
 import me.opd.enchantmentdisabler.EnchantmentDisablerPlugin;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.configuration.ConfigurationSection;
 
 public class ConfigUtilsEN {
     @SuppressWarnings("deprecation")
@@ -15,9 +16,27 @@ public class ConfigUtilsEN {
 
     @SuppressWarnings("deprecation")
     public static void loadHashMapFromConfig(EnchantmentDisablerPlugin plugin){
-        for(String path : plugin.getConfig().getConfigurationSection("enchants").getKeys(true)){
-            EnchantmentDisablerPlugin.blockedEnchants.put(Enchantment.getByName(path), (Boolean)plugin.getConfig().getBoolean("enchants." + path));
-
+        ConfigurationSection section = plugin.getConfig().getConfigurationSection("enchants");
+        if(section == null){
+            section = plugin.getConfig().createSection("enchants");
         }
+
+        // Load existing configured enchants first
+        for(String path : section.getKeys(true)){
+            Enchantment ench = Enchantment.getByName(path);
+            if(ench != null){
+                EnchantmentDisablerPlugin.blockedEnchants.put(ench, plugin.getConfig().getBoolean("enchants." + path));
+            }
+        }
+
+        // Auto-populate any missing/new enchantments with default 'false' (allowed)
+        for(Enchantment ench : Enchantment.values()){
+            if(!EnchantmentDisablerPlugin.blockedEnchants.containsKey(ench)){
+                EnchantmentDisablerPlugin.blockedEnchants.put(ench, false);
+                plugin.getConfig().set("enchants." + ench.getName(), false);
+            }
+        }
+
+        plugin.saveConfig();
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,3 +5,13 @@ main: me.opd.enchantmentdisabler.EnchantmentDisablerPlugin
 api-version: '1.20'
 commands:
   ed:
+    description: Open enchant selection GUI or reload config
+    usage: "/ed [reload]"
+    permission: enchantmentdisabler.admincommand
+permissions:
+  enchantmentdisabler.admincommand:
+    description: Access to /ed GUI
+    default: op
+  enchantmentdisabler.reload:
+    description: Allows reloading the plugin config and caches
+    default: op


### PR DESCRIPTION
- Add `/ed reload` command with proper permission.
- Reload config and caches on command.
- Auto-add missing enchantments (including new ones) to config with default `false`.
- Make checks null-safe and update GUI lore logic.